### PR TITLE
Add checkpoints download, ONNX export and verify scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+ 
+# Virtual environments
+.venv/
+venv/
+env/
+ 
+# PyTorch / ML
+*.pth
+*.pt
+*.ckpt
+*.onnx
+checkpoints/
+runs/
+wandb/
+*.log
+ 
+# OS / editor
+.DS_Store
+.idea/
+.vscode/
+ 
+# Test output
+*.png
+!assets/**/*.png

--- a/download_checkpoint.py
+++ b/download_checkpoint.py
@@ -1,0 +1,29 @@
+import argparse
+from pathlib import Path
+from huggingface_hub import hf_hub_download
+
+
+# Download checkpoints files from huggingface
+def download(repo_id, dest_dir, files):
+    dest_dir_path = Path(dest_dir)
+    dest_dir_path.mkdir(parents=True, exist_ok=True)
+    for filename in files:
+        print("Downloading", filename)
+        hf_hub_download(repo_id=repo_id, filename=filename, local_dir=dest_dir_path)
+    print("Done. Files in", dest_dir_path)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Download checkpoint files from Hugging Face.")
+    parser.add_argument("--repo_id", default="tomtomtommi/LiteAnyStereoV2", help="Hugging Face repo id")
+    parser.add_argument("--dest_dir", default="./checkpoints", help="download destination")
+    parser.add_argument("--files", nargs="+", default=["LAS2_S.pth", "LAS2_M.pth", "LAS2_L.pth", "LAS2_H.pth"],
+                         help="filenames to download")
+    return parser.parse_args()
+ 
+ 
+if __name__ == "__main__":
+    args = parse_args()
+    download(repo_id=args.repo_id,
+              dest_dir=args.dest_dir,
+              files=args.files)

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -7,6 +7,8 @@ from core.models import build_model, load_model_weights
 
 import torch.nn.functional as F
 import core.liteanystereov2 as liteanystereov2
+import core.liteanystereov2_H as liteanystereov2_H
+import core.submodule as submodule
 
 # F.unfold is not exportable to ONNX; replace it with an equivalent identity conv3x3.
 def _context_upsample(depth_low, up_weights):
@@ -34,6 +36,23 @@ def _build_correlation_volume(left_feature, right_feature, max_disp):
     return cost_volume.contiguous()
 
 
+# .unfold is not exportable to ONNX; replace it with an equivalent stack of slices.
+def _build_gwc_volume_fast(refimg_fea, targetimg_fea, maxdisp, num_groups):
+    B, C, H, W = refimg_fea.shape
+    assert C % num_groups == 0
+    channels_per_group = C // num_groups
+
+    ref_volume = refimg_fea.unsqueeze(2).expand(B, C, maxdisp, H, W)
+    padded_target = F.pad(targetimg_fea, (maxdisp - 1, 0, 0, 0))
+    unfolded_target = torch.stack([padded_target[:, :, :, i:i+W] for i in range(maxdisp)], dim=3)
+    target_volume = torch.flip(unfolded_target, [3]).permute(0, 1, 3, 2, 4)
+
+    ref_volume = ref_volume.view(B, num_groups, channels_per_group, maxdisp, H, W)
+    target_volume = target_volume.view(B, num_groups, channels_per_group, maxdisp, H, W)
+    volume = (ref_volume * target_volume).mean(dim=2)
+    return volume.contiguous()
+
+
 class Wrapper(nn.Module):
     """Bakes in max_disp/test_mode so the exported graph only takes (left, right)."""
     def __init__(self, model, max_disp):
@@ -50,8 +69,12 @@ class Wrapper(nn.Module):
 # - Export with fixed input shape.
 def export(version, model_size, restore_ckpt, width, height, max_disp, output_name):
     # Replace functions that not compatable with ONNX export with an equivalent fixed functions.
+    submodule.context_upsample = _context_upsample
     liteanystereov2.context_upsample = _context_upsample
+    liteanystereov2_H.context_upsample = _context_upsample
     liteanystereov2.build_correlation_volume = _build_correlation_volume
+    submodule.build_gwc_volume_fast = _build_gwc_volume_fast
+    liteanystereov2_H.build_gwc_volume_fast = _build_gwc_volume_fast
 
     # Load model
     model = build_model(version, model_size=model_size, max_disp=max_disp)

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,0 +1,94 @@
+import argparse
+
+import torch
+import torch.nn as nn
+
+from core.models import build_model, load_model_weights
+
+import torch.nn.functional as F
+import core.liteanystereov2 as liteanystereov2
+
+# F.unfold is not exportable to ONNX; replace it with an equivalent identity conv3x3.
+def _context_upsample(depth_low, up_weights):
+    b, c, h, w = depth_low.shape
+
+    w3 = torch.eye(9, dtype=depth_low.dtype, device=depth_low.device).reshape(9, 1, 3, 3)
+    depth_unfold = F.conv2d(depth_low.reshape(b,c,h,w), w3, padding=1).reshape(b,-1,h,w)
+    depth_unfold = F.interpolate(depth_unfold,(h*4,w*4),mode='nearest').reshape(b,9,h*4,w*4)
+
+    depth = torch.sum(depth_unfold*up_weights, dim=1, keepdim=True)
+
+    return depth
+
+
+# .unfold is not exportable to ONNX; replace it with an equivalent stack of slices.
+def _build_correlation_volume(left_feature, right_feature, max_disp):
+    B, C, H, W = left_feature.shape
+
+    left_volume = left_feature.unsqueeze(2).expand(B, C, max_disp, H, W)
+    padded_right = F.pad(right_feature, (max_disp - 1, 0, 0, 0))
+    unfolded_right = torch.stack([padded_right[:, :, :, i:i+W] for i in range(max_disp)], dim=3)
+    right_volume = torch.flip(unfolded_right, [3]).permute(0, 1, 3, 2, 4)
+
+    cost_volume = (left_volume * right_volume).mean(dim=1)
+    return cost_volume.contiguous()
+
+
+class Wrapper(nn.Module):
+    """Bakes in max_disp/test_mode so the exported graph only takes (left, right)."""
+    def __init__(self, model, max_disp):
+        super().__init__()
+        self.model = model
+        self.max_disp = max_disp
+
+    def forward(self, left, right):
+        return self.model(left, right, max_disp=self.max_disp, test_mode=True)
+
+
+# Export checkpoint to ONNX file. 
+# - Fix uncompatable functions.
+# - Export with fixed input shape.
+def export(version, model_size, restore_ckpt, width, height, max_disp, output_name):
+    # Replace functions that not compatable with ONNX export with an equivalent fixed functions.
+    liteanystereov2.context_upsample = _context_upsample
+    liteanystereov2.build_correlation_volume = _build_correlation_volume
+
+    # Load model
+    model = build_model(version, model_size=model_size, max_disp=max_disp)
+    checkpoint = torch.load(restore_ckpt, map_location="cpu")
+    load_model_weights(model, checkpoint, strict=True)
+    model = Wrapper(model.eval(), max_disp=max_disp).eval()
+
+    left = torch.randint(0, 256, (1, 3, height, width), dtype=torch.float32)
+    right = torch.randint(0, 256, (1, 3, height, width), dtype=torch.float32)
+    
+    torch.onnx.export(
+        model, (left, right), output_name,
+        input_names=["left", "right"], output_names=["disparity"],
+        opset_version=18,
+        dynamo=False
+    )
+    print("Saved", output_name)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export LiteAnyStereo checkpoint to ONNX.")
+    parser.add_argument("--version", default="las2", help="model version, e.g. las1 or las2")
+    parser.add_argument("--model_size", default="m", help="LAS2 model size: s, m, l, or h")
+    parser.add_argument("--restore_ckpt", default="./checkpoints/LAS2_M.pth", help="path to .pth checkpoint file")
+    parser.add_argument("--width", type=int, default=1248, help="export input width, per single image (not left+right combined)")
+    parser.add_argument("--height", type=int, default=384, help="export input height")
+    parser.add_argument("--max_disp", type=int, default=192, help="maximum disparity used by the model")
+    parser.add_argument("--output_name", default="liteanystereo.onnx", help="output ONNX file path")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    export(version=args.version,
+           model_size=args.model_size,
+           restore_ckpt=args.restore_ckpt,
+           width=args.width,
+           height=args.height,
+           max_disp=args.max_disp,
+           output_name=args.output_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,18 @@
+--extra-index-url https://download.pytorch.org/whl/cu126
+
+torch
+torchvision
+numpy
+scipy
+opencv-python
+pillow
+imageio
+pandas
+joblib
+open3d
+trimesh
+timm
+thop
+transformations
+onnxruntime
+onnxscript

--- a/run_onnx.py
+++ b/run_onnx.py
@@ -1,0 +1,55 @@
+import argparse
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+# Run ONNX file with test image.
+# Save visualized image 
+def run(stereo_image_name, width, height, onnx_path, output_name):
+    # Load input image.
+    # Input images are joined horizontally into a single image.
+    img = cv2.imread(stereo_image_name)[..., :3]
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    h, w = img.shape[:2]
+    img0 = img[:, : w // 2, :]
+    img1 = img[:, w // 2 :, :]
+
+    # Resize to model input size
+    img0 = cv2.resize(img0, (width, height))
+    img1 = cv2.resize(img1, (width, height))
+
+    # HWC uint8 -> NCHW float32
+    # values in 0-255 (model normalizes internally).
+    left = img0.astype(np.float32).transpose(2, 0, 1)[None]
+    right = img1.astype(np.float32).transpose(2, 0, 1)[None]
+
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    disp = sess.run(["disparity"], {"left": left, "right": right})[0]
+    disp = disp[0, 0]  # (H, W)
+
+    # Save sample output 
+    print("Disparity shape:", disp.shape, "min:", disp.min(), "max:", disp.max())
+
+    vis = (disp - disp.min()) / (disp.max() - disp.min() + 1e-6) * 255
+    vis = cv2.applyColorMap(vis.astype(np.uint8), cv2.COLORMAP_TURBO)
+    cv2.imwrite(output_name, vis)
+    print("Saved", output_name)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run ONNX model on a test image.")
+    parser.add_argument("--input", default="./assets/Explorer_HD2K_SN28883284_20-42-06.png", help="left+right stereo image")
+    parser.add_argument("--onnx_path", default="liteanystereo.onnx", help="ONNX file")
+    parser.add_argument("--output", default="disp_vis.png", help="output visualized file")
+    parser.add_argument("--width", type=int, default=1248, help="per input, not left+right")
+    parser.add_argument("--height", type=int, default=384)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run(stereo_image_name=args.input,
+        width=args.width,
+        height=args.height,
+        onnx_path=args.onnx_path,
+        output_name=args.output)

--- a/verify_onnx.py
+++ b/verify_onnx.py
@@ -1,0 +1,63 @@
+import argparse
+import numpy as np
+import torch
+import onnxruntime as ort
+
+from core.models import build_model, load_model_weights
+
+
+# Verify ONNX file with original checkpoints file.
+def verify(ckpt, version, model_size, onnx_file, width, height, max_disp):
+    # load models
+    ## Original model
+    torch.manual_seed(0)
+    left = torch.rand(1, 3, height, width, dtype=torch.float32)
+    right = torch.rand(1, 3, height, width, dtype=torch.float32)
+
+    model = build_model(version, model_size=model_size, max_disp=max_disp)
+    load_model_weights(model, torch.load(ckpt, map_location="cpu"), strict=True)
+    model.eval()
+
+    ## ONNX model
+    sess = ort.InferenceSession(onnx_file, providers=["CPUExecutionProvider"])
+
+    # run models
+    ## Original model
+    with torch.no_grad():
+        out_torch = model(left, right, max_disp=max_disp, test_mode=True)[0]
+
+    ## ONNX model
+    out_onnx = sess.run(["disparity"], {"left": left.numpy(), "right": right.numpy()})[0]
+
+    # compare
+    a = out_torch.numpy().astype(np.float64)
+    b = out_onnx.astype(np.float64)
+    diff = np.abs(a - b)
+    print("torch disparity:", a.min(), a.max())
+    print("onnx  disparity:", b.min(), b.max())
+    print("max abs diff   :", diff.max())
+    print("mean abs diff  :", diff.mean())
+    print("allclose(1e-4):", np.allclose(a, b, atol=1e-4, rtol=1e-3))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Verify ONNX export against original PyTorch model.")
+    parser.add_argument("--ckpt", default="./checkpoints/LAS2_M.pth", help="path to .pth checkpoint file")
+    parser.add_argument("--version", default="las2", help="model version, e.g. las1 or las2")
+    parser.add_argument("--model_size", default="m", help="LAS2 model size: s, m, l, or h")
+    parser.add_argument("--onnx_file", default="liteanystereo.onnx", help="path to exported ONNX file")
+    parser.add_argument("--width", type=int, default=1248, help="input width, per single image (not left+right combined)")
+    parser.add_argument("--height", type=int, default=384, help="input height")
+    parser.add_argument("--max_disp", type=int, default=192, help="maximum disparity used by the model")
+    return parser.parse_args()
+ 
+ 
+if __name__ == "__main__":
+    args = parse_args()
+    verify(ckpt=args.ckpt,
+           version=args.version,
+           model_size=args.model_size,
+           onnx_file=args.onnx_file,
+           width=args.width,
+           height=args.height,
+           max_disp=args.max_disp)


### PR DESCRIPTION
## What added?

* Add Download checkpoints script
* Add ONNX export, verify and run scripts
* Add requirements and simple .gitignore file for management

Export script has fix of ONNX uncompatable functions. Please check it. :)

> [! NOTE]
> I added ONNX export fix for LAS2 H model.

All scripts tested below module version
<details>
<summary>Tested modules</summary>

```
annotated-types           0.7.0
anyio                     4.14.1
asttokens                 3.0.1
attrs                     26.1.0
blinker                   1.9.0
certifi                   2022.12.7
charset-normalizer        2.1.1
click                     8.4.2
colorama                  0.4.6
comm                      0.2.3
configargparse            1.7.5
dash                      4.4.0
decorator                 5.3.1
executing                 2.2.1
fastjsonschema            2.21.2
filelock                  3.29.0
flask                     3.1.3
flatbuffers               25.12.19
fsspec                    2026.4.0
h11                       0.16.0
hf-xet                    1.5.1
httpcore                  1.0.9
httpx                     0.28.1
huggingface-hub           1.23.0
idna                      3.4
imageio                   2.37.3
importlib-metadata        7.1.0
ipython                   9.15.0
ipython-pygments-lexers   1.1.1
ipywidgets                8.1.8
itsdangerous              2.2.0
janus                     2.0.0
jedi                      0.20.0
jinja2                    3.1.6
joblib                    1.5.3
jsonschema                4.26.0
jsonschema-specifications 2025.9.1
jupyter-core              5.9.1
jupyterlab-widgets        3.0.16
markupsafe                3.0.3
matplotlib-inline         0.2.2
ml-dtypes                 0.5.4
mpmath                    1.3.0
narwhals                  2.23.0
nbformat                  5.10.4
nest-asyncio              1.6.0
networkx                  3.6.1
numpy                     2.4.4
onnx                      1.22.0
onnx-ir                   0.2.1
onnxruntime-gpu           1.27.0
onnxscript                0.7.1
open3d                    0.19.0
opencv-python             5.0.0.93
packaging                 24.1
pandas                    3.0.3
parso                     0.8.7
pillow                    12.2.0
platformdirs              4.10.0
plotly                    6.9.0
prompt-toolkit            3.0.52
protobuf                  7.35.1
psutil                    7.2.2
pure-eval                 0.2.3
pydantic                  2.13.4
pydantic-core             2.46.4
pygments                  2.20.0
python-dateutil           2.9.0.post0
pyyaml                    6.0.3
referencing               0.37.0
requests                  2.28.1
retrying                  1.4.2
rpds-py                   2026.6.3
safetensors               0.8.0
scipy                     1.18.0
setuptools                78.1.0
six                       1.17.0
stack-data                0.6.3
sympy                     1.14.0
thop                      0.1.1.post2209072238
timm                      1.0.27
torch                     2.13.0+cu126
torchvision               0.28.0+cu126
tqdm                      4.66.5
traitlets                 5.15.1
transformations           2026.1.18
trimesh                   4.12.2
typing-extensions         4.15.0
typing-inspection         0.4.2
tzdata                    2026.3
urllib3                   1.26.13
wcwidth                   0.8.2
werkzeug                  3.1.8
widgetsnbextension        4.0.15
zipp                      3.19.2
```

</details>

### How to setup with requirements and uv
```
python -m pip install uv
uv venv --python 3.12
uv pip install -r requirements.txt
```
* Python should be set 3.12. Open3D not work with higher version in this time :(

## Scripts

### download_checkpoint.py
* Downlaod checkpoints files from huggingface.
* Original [Here](https://huggingface.co/tomtomtommi/LiteAnyStereoV2)
* Simply "python ./download_checkpoint.py" will download "LAS2_S.pth", "LAS2_M.pth", "LAS2_L.pth", "LAS2_H.pth"
```
> python ./download_checkpoint.py --help 
usage: download_checkpoint.py [-h] [--repo_id REPO_ID] [--dest_dir DEST_DIR] [--files FILES [FILES ...]]

Download checkpoint files from Hugging Face.

options:
  -h, --help            show this help message and exit
  --repo_id REPO_ID     Hugging Face repo id
  --dest_dir DEST_DIR   download destination
  --files FILES [FILES ...]
                        filenames to download
```

### export_onnx.py
* Export ONNX files from checkpoints
* Simply "python ./export_onnx.py" will export las2 m model with fixed input size.
* Check code for more details
```
> python ./export_onnx.py --help
usage: export_onnx.py [-h] [--version VERSION] [--model_size MODEL_SIZE] [--restore_ckpt RESTORE_CKPT] [--width WIDTH] [--height HEIGHT]
                      [--max_disp MAX_DISP] [--output_name OUTPUT_NAME]

Export LiteAnyStereo checkpoint to ONNX.

options:
  -h, --help            show this help message and exit
  --version VERSION     model version, e.g. las1 or las2
  --model_size MODEL_SIZE
                        LAS2 model size: s, m, l, or h
  --restore_ckpt RESTORE_CKPT
                        path to .pth checkpoint file
  --width WIDTH         export input width, per single image (not left+right combined)
  --height HEIGHT       export input height
  --max_disp MAX_DISP   maximum disparity used by the model
  --output_name OUTPUT_NAME
                        output ONNX file path
```
Also, This scripts has fixed version of some functions. 
* unfold is not supported for ONNX export.
 ```python
    # context_upsample
    depth_unfold = F.unfold(depth_low.reshape(b,c,h,w),3,1,1).reshape(b,-1,h,w)
    # Fixed version
    w3 = torch.eye(9, dtype=depth_low.dtype, device=depth_low.device).reshape(9, 1, 3, 3)
    depth_unfold = F.conv2d(depth_low.reshape(b,c,h,w), w3, padding=1).reshape(b,-1,h,w)
 ```
    
```python
    # build_correlation_volume
    unfolded_right = padded_right.unfold(3, W, 1)
    # Fixed version
    unfolded_right = torch.stack([padded_right[:, :, :, i:i+W] for i in range(max_disp)], dim=3)
```

```python
    # build_gwc_volume_fast
    unfolded_target = padded_target.unfold(3, W, 1)
    # Fixed version
    unfolded_target = torch.stack([padded_target[:, :, :, i:i+W] for i in range(maxdisp)], dim=3)
```

Please check it in export_onnx.py. 

### verify_onnx.py
* This script compare the results of original PyTorch model and exported ONNX model.
```
> python ./verify_onnx.py --help                                         
usage: verify_onnx.py [-h] [--ckpt CKPT] [--version VERSION] [--model_size MODEL_SIZE] [--onnx_file ONNX_FILE] [--width WIDTH] [--height HEIGHT]
                      [--max_disp MAX_DISP]

Verify ONNX export against original PyTorch model.

options:
  -h, --help            show this help message and exit
  --ckpt CKPT           path to .pth checkpoint file
  --version VERSION     model version, e.g. las1 or las2
  --model_size MODEL_SIZE
                        LAS2 model size: s, m, l, or h
  --onnx_file ONNX_FILE
                        path to exported ONNX file
  --width WIDTH         input width, per single image (not left+right combined)
  --height HEIGHT       input height
  --max_disp MAX_DISP   maximum disparity used by the model
```

### run_onnx.py
* Run exported ONNX model and save output visualization image file.
```
> python ./run_onnx.py --help   
usage: run_onnx.py [-h] [--input INPUT] [--onnx_path ONNX_PATH] [--output OUTPUT] [--width WIDTH] [--height HEIGHT]

Run ONNX model on a test image.

options:
  -h, --help            show this help message and exit
  --input INPUT         left+right stereo image
  --onnx_path ONNX_PATH
                        ONNX file
  --output OUTPUT       output visualized file
  --width WIDTH         per input, not left+right
  --height HEIGHT
```
